### PR TITLE
Provide options to control shutdown

### DIFF
--- a/pages/directory-and-name-resolution.md
+++ b/pages/directory-and-name-resolution.md
@@ -113,7 +113,7 @@ public Task<SqlDatabase> Build(
         string? databaseSuffix = null,
         [CallerMemberName] string memberName = "")
 ```
-<sup><a href='/src/LocalDb/SqlInstance.cs#L120-L142' title='Snippet source file'>snippet source</a> | <a href='#snippet-conventionbuildsignature' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb/SqlInstance.cs#L132-L154' title='Snippet source file'>snippet source</a> | <a href='#snippet-conventionbuildsignature' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 With these parameters the database name is the derived as follows:
@@ -150,7 +150,7 @@ If full control over the database name is required, there is an overload that ta
 /// </summary>
 public async Task<SqlDatabase> Build(string dbName)
 ```
-<sup><a href='/src/LocalDb/SqlInstance.cs#L157-L164' title='Snippet source file'>snippet source</a> | <a href='#snippet-explicitbuildsignature' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb/SqlInstance.cs#L169-L176' title='Snippet source file'>snippet source</a> | <a href='#snippet-explicitbuildsignature' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Which can be used as follows:

--- a/src/EfClassicLocalDb/EfClassicLocalDb.csproj
+++ b/src/EfClassicLocalDb/EfClassicLocalDb.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\LocalDb\LocalDbInstanceInfo.cs" />
     <Compile Include="..\LocalDb\LocalDbApi.cs" />
     <Compile Include="..\LocalDb\MethodTimeLogger.cs" />
+    <Compile Include="..\LocalDb\ShutdownMode.cs" />
     <Compile Include="..\LocalDb\SqlExtensions.cs" />
     <Compile Include="..\LocalDb\Wrapper.cs" />
     <Compile Include="..\LocalDb\State.cs" />

--- a/src/EfClassicLocalDb/SqlInstance.cs
+++ b/src/EfClassicLocalDb/SqlInstance.cs
@@ -97,7 +97,23 @@ public class SqlInstance<TDbContext>
         return Timestamp.LastModified<TDbContext>();
     }
 
-    public void Cleanup() => Wrapper.DeleteInstance();
+    public void Cleanup()
+    {
+        Guard.AgainstBadOS();
+        Wrapper.DeleteInstance();
+    }
+
+    public void Cleanup(ShutdownMode shutdownMode)
+    {
+        Guard.AgainstBadOS();
+        Wrapper.DeleteInstance(shutdownMode);
+    }
+
+    public void Cleanup(ShutdownMode shutdownMode, TimeSpan timeout)
+    {
+        Guard.AgainstBadOS();
+        Wrapper.DeleteInstance(shutdownMode, timeout);
+    }
 
     Task<string> BuildDatabase(string dbName) => Wrapper.CreateDatabaseFromTemplate(dbName);
 

--- a/src/EfLocalDb/EfLocalDb.csproj
+++ b/src/EfLocalDb/EfLocalDb.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\LocalDb\LocalDbInstanceInfo.cs" />
     <Compile Include="..\LocalDb\LocalDbApi.cs" />
     <Compile Include="..\LocalDb\MethodTimeLogger.cs" />
+    <Compile Include="..\LocalDb\ShutdownMode.cs" />
     <Compile Include="..\LocalDb\SqlExtensions.cs" />
     <Compile Include="..\LocalDb\Wrapper.cs" />
     <Compile Include="..\LocalDb\State.cs" />

--- a/src/LocalDb/LocalDbApi.cs
+++ b/src/LocalDb/LocalDbApi.cs
@@ -1,6 +1,12 @@
 ﻿using System.ComponentModel;
 using System.Runtime.InteropServices;
 
+#if EF
+using EfLocalDb;
+#else
+using LocalDb;
+#endif
+
 static class LocalDbApi
 {
     static IntPtr api;
@@ -125,9 +131,14 @@ static class LocalDbApi
 
     public static void DeleteInstance(string instanceName) => deleteInstance(instanceName, 0);
 
-    public static void StopAndDelete(string instanceName)
+    private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(10);
+
+    public static void StopAndDelete(string instanceName, ShutdownMode shutdownMode = ShutdownMode.KillProcess) =>
+        StopAndDelete(instanceName, shutdownMode, DefaultShutdownTimeout);
+
+    public static void StopAndDelete(string instanceName, ShutdownMode shutdownMode, TimeSpan timeout)
     {
-        StopInstance(instanceName);
+        StopInstance(instanceName, shutdownMode, timeout);
         DeleteInstance(instanceName);
     }
 
@@ -160,5 +171,9 @@ static class LocalDbApi
         startInstance(instanceName, 0, connection, ref size);
     }
 
-    public static void StopInstance(string instanceName) => stopInstance(instanceName, 0, 10000);
+    public static void StopInstance(string instanceName, ShutdownMode shutdownMode = ShutdownMode.UseSqlShutdown) =>
+        StopInstance(instanceName, shutdownMode, DefaultShutdownTimeout);
+
+    public static void StopInstance(string instanceName, ShutdownMode shutdownMode, TimeSpan timeout) =>
+        stopInstance(instanceName, (int)shutdownMode, (int)timeout.TotalMilliseconds);
 }

--- a/src/LocalDb/ShutdownMode.cs
+++ b/src/LocalDb/ShutdownMode.cs
@@ -1,0 +1,32 @@
+#if EF
+namespace EfLocalDb;
+#else
+namespace LocalDb;
+#endif
+
+/// <summary>
+/// Provides options for how to shut down the instance.
+/// </summary>
+/// <remarks>
+/// See https://docs.microsoft.com/sql/relational-databases/express-localdb-instance-apis/localdbstopinstance-function
+/// </remarks>
+public enum ShutdownMode
+{
+    /// <summary>
+    /// Shutdown cleanly, using the <c>SHUTDOWN</c> T-SQL command.
+    /// See https://docs.microsoft.com/sql/t-sql/language-elements/shutdown-transact-sql
+    /// </summary>
+    UseSqlShutdown = 0,
+
+    /// <summary>
+    /// Shutdown immediately, by asking the operating system to kill the process hosting the instance.
+    /// The database may be corrupted by this approach, so only use when you intend to delete the instance.
+    /// </summary>
+    KillProcess = 1,
+
+    /// <summary>
+    /// Shutdown using the <c>SHUTDOWN WITH NOWAIT</c> T-SQL command, which does not perform checkpoints in the database.
+    /// See https://docs.microsoft.com/sql/t-sql/language-elements/shutdown-transact-sql
+    /// </summary>
+    UseSqlShutdownWithNoWait = 2
+}

--- a/src/LocalDb/SqlInstance.cs
+++ b/src/LocalDb/SqlInstance.cs
@@ -115,6 +115,18 @@ public class SqlInstance
         Wrapper.DeleteInstance();
     }
 
+    public void Cleanup(ShutdownMode shutdownMode)
+    {
+        Guard.AgainstBadOS();
+        Wrapper.DeleteInstance(shutdownMode);
+    }
+
+    public void Cleanup(ShutdownMode shutdownMode, TimeSpan timeout)
+    {
+        Guard.AgainstBadOS();
+        Wrapper.DeleteInstance(shutdownMode, timeout);
+    }
+
     Task<string> BuildContext(string dbName) => Wrapper.CreateDatabaseFromTemplate(dbName);
 
     #region ConventionBuildSignature

--- a/src/LocalDb/Wrapper.cs
+++ b/src/LocalDb/Wrapper.cs
@@ -261,9 +261,16 @@ class Wrapper
     }
 
     [Time]
-    public void DeleteInstance()
+    public void DeleteInstance(ShutdownMode shutdownMode = ShutdownMode.KillProcess)
     {
-        LocalDbApi.StopAndDelete(instance);
+        LocalDbApi.StopAndDelete(instance, shutdownMode);
+        System.IO.Directory.Delete(Directory, true);
+    }
+
+    [Time]
+    public void DeleteInstance(ShutdownMode shutdownMode, TimeSpan timeout)
+    {
+        LocalDbApi.StopAndDelete(instance, shutdownMode, timeout);
         System.IO.Directory.Delete(Directory, true);
     }
 


### PR DESCRIPTION
When shutting down the database, there are some options provided by the underlying `LocalDBStopInstance` function to control shutdown mode and timeout.

Previously, the shutdown mode was hardcoded to dwFlag `0` (uses the `SHUTDOWN` T-SQL statement), and a timeout of 10 seconds. 
 Rather than hardcoding these, it would be useful if they could be controlled.

The only public API that currently calls into this is `SqlInstance.Cleanup` - which does a shutdown and delete.  For that code path, it makes more sense for the default behavior to shutdown as fast as possible by killing the process (dwFlag `1`).  No need to have SQL cleanup if we're just going to delete the datafiles anyway.

For the other code paths (used only in tests currently), I left the default as it was previously.

After this is incorporated, it might later make sense to figure out which tests should keep the database running and which should close it.  Presently, running all tests leaves many orphaned processes.