### PR TITLE
drop System.Data.SqlClient support

### DIFF
--- a/pages/directory-and-name-resolution.md
+++ b/pages/directory-and-name-resolution.md
@@ -113,7 +113,7 @@ public Task<SqlDatabase> Build(
         string? databaseSuffix = null,
         [CallerMemberName] string memberName = "")
 ```
-<sup><a href='/src/LocalDb/SqlInstance.cs#L128-L150' title='Snippet source file'>snippet source</a> | <a href='#snippet-ConventionBuildSignature' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb/SqlInstance.cs#L99-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-ConventionBuildSignature' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 With these parameters the database name is the derived as follows:
@@ -150,7 +150,7 @@ If full control over the database name is required, there is an overload that ta
 /// </summary>
 public async Task<SqlDatabase> Build(string dbName)
 ```
-<sup><a href='/src/LocalDb/SqlInstance.cs#L165-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExplicitBuildSignature' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb/SqlInstance.cs#L136-L143' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExplicitBuildSignature' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Which can be used as follows:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,6 @@
     <Using Include="System.Security.Principal" />
     <Using Include="System.Runtime.InteropServices" />
     <Using Include="System.Linq.Expressions" />
-    <Using Include="System.Data.SqlClient.SqlConnection" Alias="DataSqlConnection" />
     <Using Include="Microsoft.Extensions.DependencyInjection" Condition="$(TargetFramework) == 'net7.0' or $(TargetFramework) == 'net8.0'" />
   </ItemGroup>
 </Project>

--- a/src/EfClassicLocalDb.Tests/Tests.cs
+++ b/src/EfClassicLocalDb.Tests/Tests.cs
@@ -1,4 +1,6 @@
-﻿[Collection("Sequential")]
+﻿using System.Data.SqlClient;
+
+[Collection("Sequential")]
 public class Tests
 {
     static SqlInstance<TestDbContext> instance;
@@ -21,7 +23,7 @@ public class Tests
     {
         static void Add(List<object?> objects, IServiceProvider provider)
         {
-            objects.Add(provider.GetService<DataSqlConnection>());
+            objects.Add(provider.GetService<SqlConnection>());
             objects.Add(provider.GetService<TestDbContext>());
         }
 

--- a/src/EfClassicLocalDb/GlobalUsings.cs
+++ b/src/EfClassicLocalDb/GlobalUsings.cs
@@ -1,2 +1,3 @@
 ﻿global using System.Data.Entity;
 global using System.ComponentModel;
+global using System.Data.SqlClient;

--- a/src/EfClassicLocalDb/QuietConfig/ManifestTokenResolver.cs
+++ b/src/EfClassicLocalDb/QuietConfig/ManifestTokenResolver.cs
@@ -7,7 +7,7 @@ class ManifestTokenResolver :
 
     public string ResolveManifestToken(DbConnection connection)
     {
-        if (connection is DataSqlConnection)
+        if (connection is SqlConnection)
         {
             return "2012";
         }

--- a/src/EfClassicLocalDb/ServiceScope.cs
+++ b/src/EfClassicLocalDb/ServiceScope.cs
@@ -1,16 +1,10 @@
 #if(NET7_0_OR_GREATER)
-class ServiceScope :
+class ServiceScope(DbContext context, SqlConnection connection) :
     IServiceScope,
     IServiceProvider
 {
-    DbContext context;
-    DataSqlConnection connection;
-
-    public ServiceScope(DbContext context, DataSqlConnection connection)
-    {
-        this.context = context;
-        this.connection = connection;
-    }
+    DbContext context = context;
+    SqlConnection connection = connection;
 
     public void Dispose()
     {
@@ -22,7 +16,7 @@ class ServiceScope :
 
     public object? GetService(Type type)
     {
-        if (type == typeof(DataSqlConnection))
+        if (type == typeof(SqlConnection))
         {
             return connection;
         }

--- a/src/EfClassicLocalDb/SqlDatabase.cs
+++ b/src/EfClassicLocalDb/SqlDatabase.cs
@@ -24,19 +24,19 @@ public partial class SqlDatabase<TDbContext> :
     }
 
     public string Name { get; }
-    public DataSqlConnection Connection { get; }
+    public SqlConnection Connection { get; }
     public string ConnectionString { get; }
 
-    public async Task<DataSqlConnection> OpenNewConnection()
+    public async Task<SqlConnection> OpenNewConnection()
     {
-        var connection = new DataSqlConnection(ConnectionString);
+        var connection = new SqlConnection(ConnectionString);
         await connection.OpenAsync();
         return connection;
     }
 
     public static implicit operator TDbContext(SqlDatabase<TDbContext> instance) => instance.Context;
 
-    public static implicit operator DataSqlConnection(SqlDatabase<TDbContext> instance) => instance.Connection;
+    public static implicit operator SqlConnection(SqlDatabase<TDbContext> instance) => instance.Connection;
 
     public async Task Start()
     {

--- a/src/EfClassicLocalDb/SqlDatabase_Service.cs
+++ b/src/EfClassicLocalDb/SqlDatabase_Service.cs
@@ -8,7 +8,7 @@ public partial class SqlDatabase<TDbContext> :
 {
     public object? GetService(Type type)
     {
-        if (type == typeof(DataSqlConnection))
+        if (type == typeof(SqlConnection))
         {
             return Connection;
         }
@@ -31,7 +31,7 @@ public partial class SqlDatabase<TDbContext> :
 #if(NET7_0_OR_GREATER)
     public IServiceScope CreateScope()
     {
-        var connection = new DataSqlConnection(ConnectionString);
+        var connection = new SqlConnection(ConnectionString);
         connection.Open();
         return new ServiceScope(NewDbContext(), connection);
     }

--- a/src/EfClassicLocalDb/SqlInstance.cs
+++ b/src/EfClassicLocalDb/SqlInstance.cs
@@ -69,7 +69,7 @@ public class SqlInstance<TDbContext>
         }
 
         Wrapper = new(
-            _ => new DataSqlConnection(_),
+            _ => new SqlConnection(_),
             storageValue.Name,
             storageValue.Directory,
             templateSize,

--- a/src/EfLocalDb.Tests/Tests.cs
+++ b/src/EfLocalDb.Tests/Tests.cs
@@ -23,7 +23,6 @@ public class Tests
     {
         static void Add(List<object?> objects, IServiceProvider provider)
         {
-            objects.Add(provider.GetService<DataSqlConnection>());
             objects.Add(provider.GetService<SqlConnection>());
             objects.Add(provider.GetService<TestDbContext>());
         }

--- a/src/EfLocalDb/EfLocalDb.csproj
+++ b/src/EfLocalDb/EfLocalDb.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Fody" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
-    <PackageReference Include="System.Data.SqlClient" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" />

--- a/src/EfLocalDb/ServiceScope.cs
+++ b/src/EfLocalDb/ServiceScope.cs
@@ -1,4 +1,4 @@
-class ServiceScope(DbContext context, DataSqlConnection dataConnection, SqlConnection connection) :
+class ServiceScope(DbContext context, SqlConnection connection) :
     IServiceScope,
     IServiceProvider,
     IAsyncDisposable
@@ -6,14 +6,12 @@ class ServiceScope(DbContext context, DataSqlConnection dataConnection, SqlConne
     public void Dispose()
     {
         connection.Dispose();
-        dataConnection.Dispose();
         context.Dispose();
     }
 
     public async ValueTask DisposeAsync()
     {
         await connection.DisposeAsync();
-        await dataConnection.DisposeAsync();
         await context.DisposeAsync();
     }
 
@@ -21,11 +19,6 @@ class ServiceScope(DbContext context, DataSqlConnection dataConnection, SqlConne
 
     public object? GetService(Type type)
     {
-        if (type == typeof(DataSqlConnection))
-        {
-            return dataConnection;
-        }
-
         if (type == typeof(SqlConnection))
         {
             return connection;

--- a/src/EfLocalDb/SqlDatabase.cs
+++ b/src/EfLocalDb/SqlDatabase.cs
@@ -28,18 +28,10 @@ public partial class SqlDatabase<TDbContext> :
         this.sqlOptionsBuilder = sqlOptionsBuilder;
         ConnectionString = connectionString;
         Connection = new(connectionString);
-        dataConnection = new(() =>
-        {
-            var connection = new DataSqlConnection(connectionString);
-            connection.Open();
-            return connection;
-        });
     }
 
     public string Name { get; }
     public SqlConnection Connection { get; }
-    Lazy<DataSqlConnection> dataConnection;
-    public DataSqlConnection DataConnection => dataConnection.Value;
     public string ConnectionString { get; }
 
     public async Task<SqlConnection> OpenNewConnection()
@@ -49,20 +41,11 @@ public partial class SqlDatabase<TDbContext> :
         return connection;
     }
 
-    public async Task<DataSqlConnection> OpenNewDataConnection()
-    {
-        var connection = new DataSqlConnection(ConnectionString);
-        await connection.OpenAsync();
-        return connection;
-    }
-
     public static implicit operator TDbContext(SqlDatabase<TDbContext> instance) => instance.Context;
 
     public static implicit operator SqlConnection(SqlDatabase<TDbContext> instance) => instance.Connection;
 
     public static implicit operator DbConnection(SqlDatabase<TDbContext> instance) => instance.Connection;
-
-    public static implicit operator DataSqlConnection(SqlDatabase<TDbContext> instance) => instance.DataConnection;
 
     public async Task Start()
     {
@@ -115,11 +98,6 @@ public partial class SqlDatabase<TDbContext> :
         // ReSharper restore ConditionIsAlwaysTrueOrFalse
 
         await Connection.DisposeAsync();
-
-        if (dataConnection.IsValueCreated)
-        {
-            await dataConnection.Value.DisposeAsync();
-        }
     }
 
     public async Task Delete()

--- a/src/EfLocalDb/SqlDatabase_Service.cs
+++ b/src/EfLocalDb/SqlDatabase_Service.cs
@@ -13,11 +13,6 @@ public partial class SqlDatabase<TDbContext> :
             return Connection;
         }
 
-        if (type == typeof(DataSqlConnection))
-        {
-            return DataConnection;
-        }
-
         if (type == typeof(TDbContext))
         {
             return Context;
@@ -38,9 +33,7 @@ public partial class SqlDatabase<TDbContext> :
     {
         var connection = new SqlConnection(ConnectionString);
         connection.Open();
-        var dataConnection = new DataSqlConnection(ConnectionString);
-        dataConnection.Open();
-        return new ServiceScope(NewDbContext(), dataConnection, connection);
+        return new ServiceScope(NewDbContext(), connection);
     }
 
     public AsyncServiceScope CreateAsyncScope() =>

--- a/src/LocalDb.Tests/Tests.cs
+++ b/src/LocalDb.Tests/Tests.cs
@@ -15,11 +15,8 @@ public class Tests
     [Fact]
     public async Task ServiceScope()
     {
-        static void Add(List<object?> objects, IServiceProvider provider)
-        {
-            objects.Add(provider.GetService<DataSqlConnection>());
+        static void Add(List<object?> objects, IServiceProvider provider) =>
             objects.Add(provider.GetService<SqlConnection>());
-        }
 
         var instance = new SqlInstance("ServiceScope", TestDbBuilder.CreateTable);
 

--- a/src/LocalDb/LocalDb.csproj
+++ b/src/LocalDb/LocalDb.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="MethodTimer.Fody" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Win32.Registry" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
-    <PackageReference Include="System.Data.SqlClient" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" />

--- a/src/LocalDb/ServiceScope.cs
+++ b/src/LocalDb/ServiceScope.cs
@@ -1,4 +1,4 @@
-class ServiceScope(DataSqlConnection dataConnection, SqlConnection connection) :
+class ServiceScope(SqlConnection connection) :
 #if(NET5_0_OR_GREATER)
     IAsyncDisposable,
 #endif
@@ -7,29 +7,18 @@ class ServiceScope(DataSqlConnection dataConnection, SqlConnection connection) :
 #endif
     IServiceProvider
 {
-    public void Dispose()
-    {
+    public void Dispose() =>
         connection.Dispose();
-        dataConnection.Dispose();
-    }
 
 #if(NET5_0_OR_GREATER)
-    public async ValueTask DisposeAsync()
-    {
-        await connection.DisposeAsync();
-        await dataConnection.DisposeAsync();
-    }
+    public ValueTask DisposeAsync() =>
+        connection.DisposeAsync();
 #endif
 
     public IServiceProvider ServiceProvider => this;
 
     public object? GetService(Type type)
     {
-        if (type == typeof(DataSqlConnection))
-        {
-            return dataConnection;
-        }
-
         if (type == typeof(SqlConnection))
         {
             return connection;

--- a/src/LocalDb/SqlDatabase.cs
+++ b/src/LocalDb/SqlDatabase.cs
@@ -14,26 +14,16 @@ public partial class SqlDatabase :
         ConnectionString = connectionString;
         Name = name;
         Connection = new(connectionString);
-        dataConnection = new(() =>
-        {
-            var connection = new DataSqlConnection(connectionString);
-            connection.Open();
-            return connection;
-        });
     }
 
     public string ConnectionString { get; }
     public string Name { get; }
 
     public SqlConnection Connection { get; }
-    Lazy<DataSqlConnection> dataConnection;
-    public DataSqlConnection DataConnection => dataConnection.Value;
 
     public static implicit operator SqlConnection(SqlDatabase instance) => instance.Connection;
 
     public static implicit operator DbConnection(SqlDatabase instance) => instance.Connection;
-
-    public static implicit operator DataSqlConnection(SqlDatabase instance) => instance.DataConnection;
 
     public async Task<SqlConnection> OpenNewConnection()
     {
@@ -42,33 +32,14 @@ public partial class SqlDatabase :
         return connection;
     }
 
-    public async Task<DataSqlConnection> OpenNewDataConnection()
-    {
-        var connection = new DataSqlConnection(ConnectionString);
-        await connection.OpenAsync();
-        return connection;
-    }
-
     public Task Start() => Connection.OpenAsync();
 
-    public void Dispose()
-    {
+    public void Dispose() =>
         Connection.Dispose();
-        if (dataConnection.IsValueCreated)
-        {
-            dataConnection.Value.Dispose();
-        }
-    }
 
 #if(!NET48)
-    public async ValueTask DisposeAsync()
-    {
-        await Connection.DisposeAsync();
-        if (dataConnection.IsValueCreated)
-        {
-            await dataConnection.Value.DisposeAsync();
-        }
-    }
+    public ValueTask DisposeAsync() =>
+        Connection.DisposeAsync();
 #endif
 
     // ReSharper disable once ReplaceAsyncWithTaskReturn

--- a/src/LocalDb/SqlDatabase_Service.cs
+++ b/src/LocalDb/SqlDatabase_Service.cs
@@ -13,11 +13,6 @@ public partial class SqlDatabase :
             return Connection;
         }
 
-        if (type == typeof(DataSqlConnection))
-        {
-            return DataConnection;
-        }
-
 #if NET7_0_OR_GREATER
         if (type == typeof(IServiceScopeFactory))
         {
@@ -33,9 +28,7 @@ public partial class SqlDatabase :
     {
         var connection = new SqlConnection(ConnectionString);
         connection.Open();
-        var dataConnection = new DataSqlConnection(ConnectionString);
-        dataConnection.Open();
-        return new ServiceScope(dataConnection, connection);
+        return new ServiceScope(connection);
     }
 
     public AsyncServiceScope CreateAsyncScope() =>

--- a/src/LocalDb/SqlInstance.cs
+++ b/src/LocalDb/SqlInstance.cs
@@ -35,35 +35,6 @@ public class SqlInstance
 
     public SqlInstance(
         string name,
-        Func<DataSqlConnection, Task> buildTemplate,
-        string? directory = null,
-        DateTime? timestamp = null,
-        ushort templateSize = 3,
-        ExistingTemplate? exitingTemplate = null,
-        Func<DataSqlConnection, Task>? callback = null) :
-        this(
-            name,
-            connection => buildTemplate((DataSqlConnection) connection),
-            directory,
-            timestamp,
-            templateSize,
-            exitingTemplate,
-            connection =>
-            {
-                if (callback == null)
-                {
-                    return Task.CompletedTask;
-                }
-
-                return callback.Invoke((DataSqlConnection) connection);
-            },
-            _ => new DataSqlConnection(_))
-    {
-    }
-
-
-    public SqlInstance(
-        string name,
         Func<SqlConnection, Task> buildTemplate,
         string? directory = null,
         DateTime? timestamp = null,


### PR DESCRIPTION
[System.Data.SqlClient package is now deprecated](https://github.com/dotnet/SqlClient/issues/2778)

If anyone requires it, i can re-add support in a different package. Just raise an issue