### PR TITLE
Evict lingering sessions when enabling read_committed_snapshot on tem…

### DIFF
--- a/pages/raw-usage.md
+++ b/pages/raw-usage.md
@@ -271,7 +271,7 @@ public async Task SharedDatabase()
     AreEqual(0, data.Count);
 }
 ```
-<sup><a href='/src/LocalDb.Tests/Tests.cs#L148-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-SharedDatabase' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb.Tests/Tests.cs#L182-L196' title='Snippet source file'>snippet source</a> | <a href='#snippet-SharedDatabase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Pass `useTransaction: true` to get an auto-rolling-back transaction, allowing writes without affecting other tests.
@@ -307,5 +307,5 @@ public async Task SharedDatabase_WithTransaction()
     AreEqual(0, data.Count);
 }
 ```
-<sup><a href='/src/LocalDb.Tests/Tests.cs#L181-L209' title='Snippet source file'>snippet source</a> | <a href='#snippet-SharedDatabase_WithTransaction' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb.Tests/Tests.cs#L215-L243' title='Snippet source file'>snippet source</a> | <a href='#snippet-SharedDatabase_WithTransaction' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/pages/template-database-size.md
+++ b/pages/template-database-size.md
@@ -21,7 +21,7 @@ To have a smaller file size [DBCC SHRINKFILE](https://docs.microsoft.com/en-us/s
 use model;
 dbcc shrinkfile(modeldev, {size})
 ```
-<sup><a href='/src/LocalDb/SqlBuilder.cs#L84-L87' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShrinkModelDb' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb/SqlBuilder.cs#L88-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShrinkModelDb' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CA1416;CS8632;NU1608;NU1109</NoWarn>
-    <Version>24.1.0</Version>
+    <Version>24.1.1</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>

--- a/src/LocalDb.Tests/Tests.cs
+++ b/src/LocalDb.Tests/Tests.cs
@@ -78,6 +78,40 @@ public class Tests
         True(callbackCalled);
     }
 
+    [Test]
+    public async Task BuildTemplateLeavesConnectionOpen()
+    {
+        // Mimics a buildTemplate callback (e.g. an SMO ServerConnection) that opens its
+        // own connection to the template and leaves it open. Setting read_committed_snapshot
+        // requires exclusive access, so the rebuild must evict that lingering session
+        // ("with rollback immediate"); otherwise the alter blocks until the command timeout.
+        SqlConnection? leaked = null;
+        using var instance = new SqlInstance(
+            "Tests_BuildTemplateLeavesConnectionOpen",
+            async connection =>
+            {
+                await TestDbBuilder.CreateTable(connection);
+                leaked = new(connection.ConnectionString);
+                await leaked.OpenAsync();
+            });
+
+        try
+        {
+            await using var database = await instance.Build();
+            var data = await TestDbBuilder.AddData(database.Connection);
+            Contains(data, await TestDbBuilder.GetData(database.Connection));
+        }
+        finally
+        {
+            if (leaked != null)
+            {
+                await leaked.DisposeAsync();
+            }
+
+            instance.Cleanup();
+        }
+    }
+
     //[Test]
     //public async Task SuppliedTemplate()
     //{

--- a/src/LocalDb/SqlBuilder.cs
+++ b/src/LocalDb/SqlBuilder.cs
@@ -58,10 +58,14 @@ static class SqlBuilder
     //                                 shared locks, preventing S/X-lock deadlocks
     //                                 between parallel [SharedDbWithTransaction] tests
     //                                 against the same shared database.
+    // read_committed_snapshot requires exclusive access to the database, so it uses
+    // "with rollback immediate" to evict any sessions a buildTemplate/callback left
+    // open (e.g. an SMO ServerConnection). Without it the statement blocks on those
+    // sessions until the command timeout expires.
     public static string TemplateSettingsCommand =
         """
         alter database [template] set auto_update_statistics off;
-        alter database [template] set read_committed_snapshot on;
+        alter database [template] set read_committed_snapshot on with rollback immediate;
         """;
 
     public static string DetachAndShrinkTemplateCommand =


### PR DESCRIPTION
…plate

Evict lingering sessions when enabling read_committed_snapshot on template read_committed_snapshot requires exclusive access to the database. The ALTER added in #932 had no termination clause, so it waited for any session a buildTemplate/callback left open instead of evicting it, blocking until the command timeout (Execution Timeout Expired). This surfaced in consumers whose callback builds schema via an SMO ServerConnection, which holds a connection to the template open persistently. LocalDb's own EF callbacks close their connections, so CI stayed green.
Add "with rollback immediate" so the statement evicts other sessions, consistent with the surrounding single_user/detach commands. Add regression test BuildTemplateLeavesConnectionOpen: without the fix the rebuild hangs ~35s then fails; with it, passes in ~10s.