### PR TITLE
Disable the default trace and system_health on new instances

### DIFF
--- a/pages/template-database-size.md
+++ b/pages/template-database-size.md
@@ -21,7 +21,7 @@ To have a smaller file size [DBCC SHRINKFILE](https://docs.microsoft.com/en-us/s
 use model;
 dbcc shrinkfile(modeldev, {size})
 ```
-<sup><a href='/src/LocalDb/SqlBuilder.cs#L98-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShrinkModelDb' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb/SqlBuilder.cs#L118-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShrinkModelDb' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/LocalDb.Tests/InstanceDiagnosticsTests.cs
+++ b/src/LocalDb.Tests/InstanceDiagnosticsTests.cs
@@ -1,0 +1,45 @@
+[TestFixture]
+public class InstanceDiagnosticsTests
+{
+    [Test]
+    public async Task DisabledOnNewInstance()
+    {
+        var name = "InstanceDiagnosticsTest";
+        LocalDbApi.StopAndDelete(name);
+        DirectoryFinder.Delete(name);
+
+        // a new instance runs the optimize commands, an existing one does not
+        using var wrapper = new Wrapper(name, DirectoryFinder.Find(name));
+        wrapper.Start(new(2000, 1, 1), TestDbBuilder.CreateTable);
+        await wrapper.AwaitStart();
+
+        try
+        {
+            await using var connection = new SqlConnection(wrapper.MasterConnectionString);
+            await connection.OpenAsync();
+
+            AreEqual(
+                0,
+                await Scalar(connection, "select value_in_use from sys.configurations where name = 'default trace enabled'"));
+            AreEqual(
+                0,
+                await Scalar(connection, "select count(*) from sys.dm_xe_sessions where name = 'system_health'"));
+            AreEqual(
+                0,
+                await Scalar(connection, "select startup_state from sys.server_event_sessions where name = 'system_health'"));
+        }
+        finally
+        {
+            DirectoryCleaner.RemoveInstance(name);
+            DirectoryFinder.Delete(name);
+        }
+    }
+
+    static async Task<int> Scalar(SqlConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result);
+    }
+}

--- a/src/LocalDb/SqlBuilder.cs
+++ b/src/LocalDb/SqlBuilder.cs
@@ -88,12 +88,32 @@ static class SqlBuilder
         execute sp_detach_db N'template', 'true';
         """;
 
+    // The default trace and the system_health session write diagnostics for the life of the
+    // instance into the directory LocalDB owns, which is never cleaned while the instance
+    // exists. Measured across ~280 instances they account for 18% of the on-disk size, and
+    // neither is of much use for a throwaway test instance. This is not a speed up:
+    // both are written in the background rather than on the startup path, and disabling
+    // them made no measurable difference to instance start time.
+    // hkenginexesession, the other event session that writes here, is owned by the XTP
+    // engine, is absent from sys.server_event_sessions, and cannot be altered.
     public static string GetOptimizeModelDbCommand(ushort size, ushort shutdownTimeout) =>
         $"""
          execute sp_configure 'show advanced options', 1;
          reconfigure;
          execute sp_configure 'user instance timeout', {shutdownTimeout};
          reconfigure;
+         execute sp_configure 'default trace enabled', 0;
+         reconfigure;
+
+         if exists (select * from sys.dm_xe_sessions where name = 'system_health')
+         begin
+             alter event session system_health on server state = stop;
+         end;
+
+         if exists (select * from sys.server_event_sessions where name = 'system_health')
+         begin
+             alter event session system_health on server with (startup_state = off);
+         end;
 
          -- begin-snippet: ShrinkModelDb
          use model;


### PR DESCRIPTION
Both write diagnostics for the life of the instance into the directory LocalDB owns, which is never cleaned while the instance exists. Measured across ~280 instances they account for 18% of the on-disk size, and neither is of much use for a throwaway test instance.

This is not a speed up. Both are written in the background rather than on the startup path: over five stop/start cycles a tuned instance averaged 891ms against 896ms for a baseline one, which is noise.

The commands go in GetOptimizeModelDbCommand, which only runs when the instance is created, and the settings live in master so they hold for the life of the instance.

hkenginexesession, the other event session writing to that directory, is owned by the XTP engine, is absent from sys.server_event_sessions and cannot be altered.