### PR TITLE
Fill pooled databases in the background, and disable page verification

### DIFF
--- a/pages/template-database-size.md
+++ b/pages/template-database-size.md
@@ -21,7 +21,7 @@ To have a smaller file size [DBCC SHRINKFILE](https://docs.microsoft.com/en-us/s
 use model;
 dbcc shrinkfile(modeldev, {size})
 ```
-<sup><a href='/src/LocalDb/SqlBuilder.cs#L118-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShrinkModelDb' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/LocalDb/SqlBuilder.cs#L127-L130' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShrinkModelDb' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Benchmark/PageVerifyBenchmarks.cs
+++ b/src/Benchmark/PageVerifyBenchmarks.cs
@@ -1,0 +1,98 @@
+/// <summary>
+/// Measures <c>page_verify none</c> against the model-database default of <c>checksum</c>.
+///
+/// Under CHECKSUM, SQL Server computes a checksum over each 8KB page immediately before it is
+/// written to disk, and re-verifies it whenever the page is read back. That exists to detect
+/// storage corrupting a page underneath the engine. Test databases are rebuilt from a template
+/// and deleted at the end of a run, so a corrupt page is worth nothing to detect: the cost is
+/// paid on every page write for a signal no one ever reads.
+///
+/// The workload isolates the page-write path: one set-based insert dirties a few thousand data
+/// pages, then an explicit checkpoint forces them all to disk in one go. Rows are fixed-width
+/// and near a page eighth, so row count maps predictably onto page count. delayed_durability is
+/// already forced by the template, so commits do not wait on the log and the checkpoint is what
+/// drives the measured I/O.
+///
+/// The table is truncated between iterations, so after warmup the file has reached its steady
+/// size and no iteration pays for file growth.
+/// </summary>
+[MemoryDiagnoser]
+[WarmupCount(3)]
+[IterationCount(20)]
+[GcServer(true)]
+[SuppressMessage("Performance", "CA1822:Mark members as static")]
+public class PageVerifyBenchmarks
+{
+    const string InstanceName = "Benchmark";
+    const string DatabaseName = "PageVerify";
+
+    // char(900) plus the int key puts eight rows on a page, so this dirties ~7500 data pages
+    // (~60MB) per iteration - enough page writes for a per-page cost to show up.
+    const int Rows = 60000;
+
+    SqlInstance? sqlInstance;
+    SqlConnection? connection;
+
+    [Params("checksum", "none")]
+    public string PageVerify { get; set; } = "checksum";
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        LocalDbApi.StopAndDelete(InstanceName);
+        DirectoryFinder.Delete(InstanceName);
+
+        sqlInstance = new(
+            name: InstanceName,
+            buildTemplate: _ => Execute(
+                _,
+                """
+                create table dbo.Rows
+                (
+                    Id int identity primary key,
+                    Padding char(900) not null
+                );
+                """));
+        await sqlInstance.Wrapper.AwaitStart();
+
+        var database = await sqlInstance.Build(DatabaseName);
+        connection = database.Connection;
+        await Execute(connection, $"alter database [{DatabaseName}] set page_verify {PageVerify};");
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        sqlInstance?.Cleanup(ShutdownMode.KillProcess);
+        sqlInstance?.Dispose();
+        sqlInstance = null;
+    }
+
+    [IterationSetup]
+    public void IterationSetup() =>
+        Execute(connection!,
+                """
+                truncate table dbo.Rows;
+                checkpoint;
+                """)
+            .GetAwaiter()
+            .GetResult();
+
+    [Benchmark]
+    public Task InsertAndCheckpoint() =>
+        Execute(connection!,
+            $"""
+             insert dbo.Rows (Padding)
+             select top ({Rows}) 'x'
+             from sys.all_objects a
+             cross join sys.all_objects b;
+             checkpoint;
+             """);
+
+    static async Task Execute(SqlConnection connection, string commandText)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Benchmark/PooledWriteSettingsBenchmarks.cs
+++ b/src/Benchmark/PooledWriteSettingsBenchmarks.cs
@@ -1,0 +1,134 @@
+/// <summary>
+/// Measures read_committed_snapshot, which a pooled lease does not need, against the
+/// write-then-roll-back shape that every pooled test has.
+///
+/// read_committed_snapshot is set on the template for the shared database, where parallel
+/// transactional tests hit the same database and would otherwise deadlock on S/X locks. A
+/// pooled database is leased exclusively - one test, one connection, one transaction, enforced
+/// by the lease semaphore - so nothing there can contend, and the row versioning is paid for
+/// no benefit: 14 bytes appended to every modified row plus a version record per update and
+/// delete.
+///
+/// accelerated_database_recovery was the other candidate here, since every pooled lease ends in
+/// a rollback and ADR makes rollback near-instant. It cannot be measured or used: LocalDB is
+/// Express edition, and enabling it fails with error 12128, "Accelerated Database Recovery
+/// cannot be enabled in the Express edition of SQL Server".
+///
+/// The workload updates and deletes rows that were committed in the template (the case that
+/// actually generates versions), inserts some more, then rolls the whole thing back.
+///
+/// Result: turning it off is worth ~11% wall clock, ~29% less write I/O, ~38% less read I/O and
+/// ~44% less SQL Server memory, consistently across runs. It is deliberately NOT applied. The
+/// setting is what lets a second connection to a leased database read while the lease holds an
+/// uncommitted write, and that is public API - OpenNewConnection, NewConnectionOwnedDbContext,
+/// and IDbContextFactory.CreateDbContext all open one. With RCSI on such a read returns the
+/// last committed state; with it off the same read blocks on the lease's X locks until the
+/// command timeout expires. This benchmark is kept as the record of that trade.
+/// </summary>
+[MemoryDiagnoser]
+[WarmupCount(3)]
+[IterationCount(20)]
+[GcServer(true)]
+[SuppressMessage("Performance", "CA1822:Mark members as static")]
+public class PooledWriteSettingsBenchmarks
+{
+    const string InstanceName = "Benchmark";
+    const string DatabaseName = "PooledWriteSettings";
+    const int Seed = 20000;
+    const int Churn = 5000;
+
+    SqlInstance? sqlInstance;
+    SqlConnection? connection;
+
+    [Params(true, false)]
+    public bool Rcsi { get; set; }
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        LocalDbApi.StopAndDelete(InstanceName);
+        DirectoryFinder.Delete(InstanceName);
+
+        sqlInstance = new(name: InstanceName, buildTemplate: BuildTemplate);
+        await sqlInstance.Wrapper.AwaitStart();
+
+        var created = await sqlInstance.Wrapper.CreateDatabaseFromTemplate(DatabaseName);
+        await created.DisposeAsync();
+
+        // Needs exclusive access, so it is applied from master before the working connection
+        // is opened.
+        await using (var master = new SqlConnection(sqlInstance.Wrapper.MasterConnectionString))
+        {
+            await master.OpenAsync();
+            await Execute(master,
+                $"alter database [{DatabaseName}] set read_committed_snapshot {OnOff(Rcsi)} with rollback immediate;");
+        }
+
+        connection = await sqlInstance.Wrapper.OpenExistingDatabase(DatabaseName);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        sqlInstance?.Cleanup(ShutdownMode.KillProcess);
+        sqlInstance?.Dispose();
+        sqlInstance = null;
+    }
+
+    /// <summary>
+    /// One pooled test: take the lease's transaction, write, roll back on release. Because it
+    /// always rolls back, the database is identical at the start of every iteration.
+    /// </summary>
+    [Benchmark]
+    public async Task WriteAndRollback()
+    {
+        var transaction = (SqlTransaction) await connection!.BeginTransactionAsync();
+        try
+        {
+            await Execute(connection,
+                $"""
+                 update dbo.Rows set Value = N'updated';
+                 delete top ({Churn}) from dbo.Rows;
+                 insert dbo.Rows (Value)
+                 select top ({Churn}) N'inserted'
+                 from sys.all_objects a
+                 cross join sys.all_objects b;
+                 """,
+                transaction);
+            await transaction.RollbackAsync();
+        }
+        finally
+        {
+            await transaction.DisposeAsync();
+        }
+    }
+
+    static string OnOff(bool value) => value ? "on" : "off";
+
+    static async Task BuildTemplate(SqlConnection connection)
+    {
+        await Execute(connection,
+            """
+            create table dbo.Rows
+            (
+                Id int identity primary key,
+                Value nvarchar(100) not null
+            );
+            """);
+        await Execute(connection,
+            $"""
+             insert dbo.Rows (Value)
+             select top ({Seed}) N'seeded'
+             from sys.all_objects a
+             cross join sys.all_objects b;
+             """);
+    }
+
+    static async Task Execute(SqlConnection connection, string commandText, SqlTransaction? transaction = null)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        command.Transaction = transaction;
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -15,5 +15,6 @@ BenchmarkSwitcher.FromTypes(
     typeof(DelayedDurabilityBenchmarks),
     typeof(AutoCloseBenchmarks),
     typeof(PooledDatabaseBenchmarks),
-    typeof(PageVerifyBenchmarks)
+    typeof(PageVerifyBenchmarks),
+    typeof(PooledWriteSettingsBenchmarks)
 ]).Run(args, config);

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -1,4 +1,4 @@
-using BenchmarkDotNet.Configs;
+﻿using BenchmarkDotNet.Configs;
 
 var config = DefaultConfig.Instance
     .AddDiagnoser(new SqlServerDiagnoser());
@@ -14,5 +14,6 @@ BenchmarkSwitcher.FromTypes(
     typeof(MixedPageContentionBenchmarks),
     typeof(DelayedDurabilityBenchmarks),
     typeof(AutoCloseBenchmarks),
-    typeof(PooledDatabaseBenchmarks)
+    typeof(PooledDatabaseBenchmarks),
+    typeof(PageVerifyBenchmarks)
 ]).Run(args, config);

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -16,5 +16,7 @@ BenchmarkSwitcher.FromTypes(
     typeof(AutoCloseBenchmarks),
     typeof(PooledDatabaseBenchmarks),
     typeof(PageVerifyBenchmarks),
-    typeof(PooledWriteSettingsBenchmarks)
+    typeof(PooledWriteSettingsBenchmarks),
+    typeof(RollbackCostBenchmarks),
+    typeof(ResetStrategyBenchmarks)
 ]).Run(args, config);

--- a/src/Benchmark/ResetStrategyBenchmarks.cs
+++ b/src/Benchmark/ResetStrategyBenchmarks.cs
@@ -1,0 +1,160 @@
+/// <summary>
+/// Compares the two ways a pooled database can be returned to its baseline after a test has
+/// written to it: rolling the lease's transaction back, or reverting the whole database from a
+/// database snapshot.
+///
+/// This is the closest thing LocalDB offers to what accelerated_database_recovery would have
+/// given, which is undo whose cost does not scale with the size of the transaction. ADR is
+/// blocked on Express (error 12128), but database snapshots do work on LocalDB, and a revert is
+/// a page-level operation against the snapshot's sparse file rather than a walk backwards
+/// through the log.
+///
+/// Both arms do the same logical thing - write Writes rows, then put the database back - so the
+/// comparison is end to end. The snapshot arm includes closing and reopening the connection,
+/// because a revert needs exclusive access to the database, and that reconnect is a real cost
+/// of the approach rather than an artifact of the benchmark.
+///
+/// Result: revert loses badly. 172ms against 0.47ms at 100 rows (370x), and 307ms against 27ms
+/// at 10000 rows (11x). Its cost is almost entirely fixed - dropping the connection, rebuilding
+/// the log, invalidating the buffer pool - so the gap narrows as the write grows but never
+/// closes at any volume a test reaches. Rolling back the lease's transaction stays the right
+/// mechanism, and snapshots are recorded here as measured and rejected.
+///
+/// Note the I/O columns from SqlServerDiagnoser are not comparable between the two arms: BDN
+/// runs vastly more invocations of the fast arm than the slow one, so those totals reflect
+/// invocation count rather than per-operation cost. Only Mean and Ratio are per operation.
+/// </summary>
+[WarmupCount(3)]
+[IterationCount(15)]
+[GcServer(true)]
+[SuppressMessage("Performance", "CA1822:Mark members as static")]
+public class ResetStrategyBenchmarks
+{
+    const string InstanceName = "Benchmark";
+    const string DatabaseName = "ResetStrategy";
+    const string SnapshotName = "ResetStrategy_snap";
+    const int Seed = 50000;
+
+    SqlInstance? sqlInstance;
+    SqlConnection? connection;
+    string snapshotFile = null!;
+
+    [Params(100, 10000)]
+    public int Writes { get; set; }
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        LocalDbApi.StopAndDelete(InstanceName);
+        DirectoryFinder.Delete(InstanceName);
+
+        sqlInstance = new(name: InstanceName, buildTemplate: BuildTemplate);
+        await sqlInstance.Wrapper.AwaitStart();
+
+        var created = await sqlInstance.Wrapper.CreateDatabaseFromTemplate(DatabaseName);
+        await created.DisposeAsync();
+
+        snapshotFile = Path.Combine(sqlInstance.Wrapper.Directory, $"{SnapshotName}.ss");
+
+        await using (var master = await OpenMaster())
+        {
+            await using var nameCommand = master.CreateCommand();
+            nameCommand.CommandText = $"select top 1 name from [{DatabaseName}].sys.database_files where type = 0;";
+            var logical = (string) (await nameCommand.ExecuteScalarAsync())!;
+
+            await Execute(master,
+                $"""
+                 create database [{SnapshotName}] on
+                 (
+                     name = [{logical}],
+                     filename = '{snapshotFile}'
+                 )
+                 as snapshot of [{DatabaseName}];
+                 """);
+        }
+
+        connection = await sqlInstance.Wrapper.OpenExistingDatabase(DatabaseName);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        sqlInstance?.Cleanup(ShutdownMode.KillProcess);
+        sqlInstance?.Dispose();
+        sqlInstance = null;
+    }
+
+    /// <summary>
+    /// What BuildPooled does today: the writes happen inside the lease's transaction, and the
+    /// rollback on release undoes them.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public async Task TransactionRollback()
+    {
+        var transaction = (SqlTransaction) await connection!.BeginTransactionAsync();
+        try
+        {
+            await Execute(connection, UpdateCommand, transaction);
+            await transaction.RollbackAsync();
+        }
+        finally
+        {
+            await transaction.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// The alternative: let the writes commit, then revert the whole database from the snapshot.
+    /// </summary>
+    [Benchmark]
+    public async Task SnapshotRevert()
+    {
+        await Execute(connection!, UpdateCommand);
+
+        // Revert needs exclusive access, so the lease's connection has to go first.
+        await connection!.DisposeAsync();
+
+        await using (var master = await OpenMaster())
+        {
+            await Execute(master, $"restore database [{DatabaseName}] from database_snapshot = '{SnapshotName}';");
+        }
+
+        connection = await sqlInstance!.Wrapper.OpenExistingDatabase(DatabaseName);
+    }
+
+    string UpdateCommand => $"update top ({Writes}) dbo.Rows set Value = N'updated';";
+
+    async Task<SqlConnection> OpenMaster()
+    {
+        var master = new SqlConnection(sqlInstance!.Wrapper.MasterConnectionString);
+        await master.OpenAsync();
+        return master;
+    }
+
+    static async Task BuildTemplate(SqlConnection connection)
+    {
+        await Execute(connection,
+            """
+            create table dbo.Rows
+            (
+                Id int identity primary key,
+                Value nvarchar(100) not null
+            );
+            """);
+        await Execute(connection,
+            $"""
+             insert dbo.Rows (Value)
+             select top ({Seed}) N'seeded'
+             from sys.all_objects a
+             cross join sys.all_objects b;
+             """);
+    }
+
+    static async Task Execute(SqlConnection connection, string commandText, SqlTransaction? transaction = null)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        command.Transaction = transaction;
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Benchmark/RollbackCostBenchmarks.cs
+++ b/src/Benchmark/RollbackCostBenchmarks.cs
@@ -1,0 +1,109 @@
+/// <summary>
+/// Measures what a pooled lease actually spends on its rollback, as write volume grows.
+///
+/// Every pooled lease ends by rolling its transaction back, which is the workload
+/// accelerated_database_recovery is built for: ADR undoes from a persisted version store, so
+/// rollback is near-instant and independent of transaction size, where a traditional rollback
+/// walks the log backwards and costs roughly one undo per log record. ADR cannot be enabled on
+/// LocalDB (Express edition, error 12128), so the question is whether that matters - which
+/// depends entirely on how much a rollback of a test-sized transaction actually costs.
+///
+/// The write is done in IterationSetup and excluded from the measurement, so the number here is
+/// the rollback alone. Writes is the row count modified inside the transaction, swept across
+/// three orders of magnitude to show how rollback scales.
+///
+/// Result: a fixed floor of ~85us plus ~0.94us per modified row, linear as expected for
+/// log-walking undo. That is the whole size of the gap ADR would close, and at the volumes a
+/// test actually writes it is nothing: 10 rows costs ~93us and 100 rows ~161us. It only becomes
+/// material for a test modifying tens of thousands of rows, where it reaches ~9.5ms.
+/// </summary>
+[WarmupCount(3)]
+[IterationCount(20)]
+[GcServer(true)]
+[SuppressMessage("Performance", "CA1822:Mark members as static")]
+public class RollbackCostBenchmarks
+{
+    const string InstanceName = "Benchmark";
+    const string DatabaseName = "RollbackCost";
+    const int Seed = 50000;
+
+    SqlInstance? sqlInstance;
+    SqlConnection? connection;
+    SqlTransaction? transaction;
+
+    /// <summary>
+    /// Rows modified inside the lease's transaction before it is rolled back.
+    /// </summary>
+    [Params(10, 100, 1000, 10000)]
+    public int Writes { get; set; }
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        LocalDbApi.StopAndDelete(InstanceName);
+        DirectoryFinder.Delete(InstanceName);
+
+        sqlInstance = new(name: InstanceName, buildTemplate: BuildTemplate);
+        await sqlInstance.Wrapper.AwaitStart();
+
+        var created = await sqlInstance.Wrapper.CreateDatabaseFromTemplate(DatabaseName);
+        await created.DisposeAsync();
+        connection = await sqlInstance.Wrapper.OpenExistingDatabase(DatabaseName);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        sqlInstance?.Cleanup(ShutdownMode.KillProcess);
+        sqlInstance?.Dispose();
+        sqlInstance = null;
+    }
+
+    [IterationSetup]
+    public void IterationSetup() => Arrange().GetAwaiter().GetResult();
+
+    [Benchmark]
+    public async Task Rollback()
+    {
+        await transaction!.RollbackAsync();
+        await transaction.DisposeAsync();
+        transaction = null;
+    }
+
+    async Task Arrange()
+    {
+        transaction = (SqlTransaction) await connection!.BeginTransactionAsync();
+        await Execute(connection,
+            $"""
+             update top ({Writes}) dbo.Rows set Value = N'updated';
+             """,
+            transaction);
+    }
+
+    static async Task BuildTemplate(SqlConnection connection)
+    {
+        await Execute(connection,
+            """
+            create table dbo.Rows
+            (
+                Id int identity primary key,
+                Value nvarchar(100) not null
+            );
+            """);
+        await Execute(connection,
+            $"""
+             insert dbo.Rows (Value)
+             select top ({Seed}) N'seeded'
+             from sys.all_objects a
+             cross join sys.all_objects b;
+             """);
+    }
+
+    static async Task Execute(SqlConnection connection, string commandText, SqlTransaction? transaction = null)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = commandText;
+        command.Transaction = transaction;
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/LocalDb.Tests/PooledFillFailureTests.cs
+++ b/src/LocalDb.Tests/PooledFillFailureTests.cs
@@ -1,0 +1,74 @@
+// Mutates LocalDbSettings.PoolSize, which is a global, so it must not overlap other fixtures.
+[TestFixture]
+[NonParallelizable]
+public class PooledFillFailureTests
+{
+    static DateTime timestamp = new(2000, 1, 1);
+
+    [Test]
+    public async Task FillFailureWakesWaitersInsteadOfHanging()
+    {
+        var name = "PooledFillFailure";
+        LocalDbApi.StopAndDelete(name);
+        DirectoryFinder.Delete(name);
+
+        var originalPoolSize = LocalDbSettings.PoolSize;
+        LocalDbSettings.PoolSize = 3;
+        try
+        {
+            using var wrapper = new Wrapper(name, DirectoryFinder.Find(name));
+            wrapper.Start(timestamp, TestDbBuilder.CreateTable);
+            await wrapper.AwaitStart();
+
+            // Pooled1 is built normally. Pooled2 stalls in the fill until the test has a
+            // second lease parked on the semaphore, then faults.
+            var faultReached = new TaskCompletionSource();
+            var releaseFault = new TaskCompletionSource();
+            var built = 0;
+
+            async Task Initialize(SqlConnection connection)
+            {
+                if (Interlocked.Increment(ref built) == 1)
+                {
+                    return;
+                }
+
+                faultReached.TrySetResult();
+                await releaseFault.Task;
+                throw new("Injected pool fill failure");
+            }
+
+            // Returns once Pooled1 exists, rather than once the whole pool does.
+            var (first, firstName) = await wrapper.OpenPooledDatabase(Initialize);
+            AreEqual("Pooled1", firstName);
+            await faultReached.Task;
+
+            // Pooled1 is leased and nothing else is built yet, so this parks on poolLease.
+            // That is the state a background failure has to be able to wake.
+            var blocked = wrapper.OpenPooledDatabase();
+            var early = await Task.WhenAny(blocked, Task.Delay(500));
+            AreNotSame(blocked, early, "second lease should still be waiting on an unbuilt database");
+
+            releaseFault.SetResult();
+
+            var finished = await Task.WhenAny(blocked, Task.Delay(TimeSpan.FromSeconds(30)));
+            AreSame(blocked, finished, "the parked lease was never woken by the fill failure");
+
+            var waiter = ThrowsAsync<Exception>(async () => await blocked)!;
+            AreEqual("Failed to build the pooled databases in the background.", waiter.Message);
+            AreEqual("Injected pool fill failure", waiter.InnerException!.Message);
+
+            // A lease arriving after the failure fails fast rather than waiting.
+            var later = ThrowsAsync<Exception>(async () => await wrapper.OpenPooledDatabase())!;
+            AreEqual("Failed to build the pooled databases in the background.", later.Message);
+            AreEqual("Injected pool fill failure", later.InnerException!.Message);
+
+            await first.DisposeAsync();
+            wrapper.DeleteInstance();
+        }
+        finally
+        {
+            LocalDbSettings.PoolSize = originalPoolSize;
+        }
+    }
+}

--- a/src/LocalDb/SqlBuilder.cs
+++ b/src/LocalDb/SqlBuilder.cs
@@ -1,4 +1,4 @@
-static class SqlBuilder
+﻿static class SqlBuilder
 {
     public static string GetCreateOrMakeOnlineCommand(string name, string dataFile, string logFile)
     {
@@ -60,6 +60,14 @@ static class SqlBuilder
     //                                 thousands of tiny commits. Benchmark
     //                                 (DelayedDurabilityBenchmarks): autocommit inserts are
     //                                 ~40% faster and write ~70% less log I/O.
+    //   page_verify none            - checksum makes the engine compute a checksum over every
+    //                                 8KB page as it is written to disk, and re-verify it on
+    //                                 read, to detect storage corrupting a page underneath it.
+    //                                 These databases are rebuilt from the template and deleted
+    //                                 with the run, so that signal is worth nothing. Benchmark
+    //                                 (PageVerifyBenchmarks): a checkpoint-heavy insert is ~5%
+    //                                 faster on average, and writes the same bytes either way -
+    //                                 the saving is CPU, not I/O.
     //   read_committed_snapshot on  - READ COMMITTED uses row versioning instead of
     //                                 shared locks, preventing S/X-lock deadlocks
     //                                 between parallel transactional tests
@@ -75,6 +83,7 @@ static class SqlBuilder
         """
         alter database [template] set auto_update_statistics off;
         alter database [template] set delayed_durability = forced;
+        alter database [template] set page_verify none;
         alter database [template] set read_committed_snapshot on with rollback immediate;
         """;
 

--- a/src/LocalDb/Wrapper.cs
+++ b/src/LocalDb/Wrapper.cs
@@ -13,6 +13,8 @@ class Wrapper : IDisposable
     SemaphoreSlim? poolLease;
     ConcurrentQueue<string> poolAvailable = new();
     bool poolCreated;
+    Task? poolFill;
+    volatile Exception? poolFillException;
     public readonly string MasterConnectionString;
     string instance;
     public readonly string DataFile;
@@ -175,13 +177,19 @@ class Wrapper : IDisposable
             }
         }
 
-        // Blocks once every pooled database is leased, which is what bounds pooled
-        // concurrency to PoolSize.
+        ThrowIfPoolFillFailed();
+
+        // Blocks once every database built so far is leased, which is what bounds pooled
+        // concurrency to PoolSize. Early in a run it can also block on a database the
+        // background fill has not produced yet.
         await poolLease!.WaitAsync();
 
         if (!poolAvailable.TryDequeue(out var name))
         {
+            // Put the permit back so the next caller reaches the same conclusion rather than
+            // waiting on a database that will never arrive.
             poolLease.Release();
+            ThrowIfPoolFillFailed();
             throw new("Pooled database lease was acquired but no database was available. This indicates a release was missed.");
         }
 
@@ -209,13 +217,54 @@ class Wrapper : IDisposable
         // would otherwise surface as an ArgumentOutOfRangeException from SemaphoreSlim on the
         // first pooled test, with nothing naming PoolSize as the cause.
         Guard.AgainstZeroPoolSize(size);
-        poolLease = new(size, size);
 
-        for (var index = 1; index <= size; index++)
+        // Starts empty and gains a permit as each database lands, rather than starting full.
+        // That is what lets a lease be served off the databases that exist so far, instead of
+        // every lease waiting for the whole pool.
+        poolLease = new(0, size);
+
+        // Only the first database is awaited, so the first pooled test pays one file copy and
+        // attach rather than PoolSize of them. The rest fill in on a background task while
+        // that test runs, and a test needing more concurrency than is built yet simply waits
+        // on poolLease until the next database lands.
+        await AddPooled(1, initialize);
+
+        poolFill = Task.Run(() => FillPool(size, initialize));
+    }
+
+    async Task FillPool(ushort size, Func<SqlConnection, Task>? initialize)
+    {
+        var index = 2;
+        try
         {
-            var name = $"Pooled{index}";
-            var connection = await CreateDatabaseFromTemplate(name);
+            // Deliberately serial: the fill now runs alongside tests, and PoolSize concurrent
+            // file copies would compete with them for the same disk.
+            for (; index <= size; index++)
+            {
+                await AddPooled(index, initialize);
+            }
+        }
+        catch (Exception exception)
+        {
+            // A background failure must not leave leases waiting on databases that will never
+            // arrive. Record the cause first, then release one permit per unbuilt database so
+            // every waiter wakes, finds nothing to dequeue, and rethrows that cause. This can
+            // never exceed the semaphore maximum: index - 1 databases were built, so at most
+            // index - 1 permits are outstanding.
+            poolFillException = exception;
+            poolLease!.Release(size - index + 1);
+            return;
+        }
 
+        LocalDbLogging.LogIfVerbose($"Created pool of {size} databases");
+    }
+
+    async Task AddPooled(int index, Func<SqlConnection, Task>? initialize)
+    {
+        var name = $"Pooled{index}";
+        var connection = await CreateDatabaseFromTemplate(name);
+        try
+        {
             // Attach resets auto_close to the model default (on), under which the database
             // shuts down whenever its last connection closes and the next lease pays a full
             // database startup. Pooled databases are reopened once per test for the lifetime
@@ -226,17 +275,35 @@ class Wrapper : IDisposable
             {
                 await initialize(connection);
             }
-
+        }
+        finally
+        {
+            // Also on the failure path, so a fill that dies part way does not strand a
+            // connection against a database no one will ever lease.
 #if NET5_0_OR_GREATER
             await connection.DisposeAsync();
 #else
             connection.Dispose();
 #endif
-            poolAvailable.Enqueue(name);
         }
 
-        LocalDbLogging.LogIfVerbose($"Created pool of {size} databases");
+        // Enqueue before releasing, so a waiter woken by the release always finds a database.
+        poolAvailable.Enqueue(name);
+        poolLease!.Release();
     }
+
+    void ThrowIfPoolFillFailed()
+    {
+        var exception = poolFillException;
+        if (exception != null)
+        {
+            throw new("Failed to build the pooled databases in the background.", exception);
+        }
+    }
+
+    // Teardown deletes the instance directory, so a background fill still copying files into
+    // it has to finish first. FillPool swallows its own failure, so this cannot throw.
+    void WaitForPoolFill() => poolFill?.GetAwaiter().GetResult();
 
     public async Task<SqlConnection> OpenSharedDatabase(
         Func<SqlConnection, Task>? initialize = null)
@@ -427,6 +494,7 @@ class Wrapper : IDisposable
     [Time]
     public void DeleteInstance(ShutdownMode mode = ShutdownMode.KillProcess)
     {
+        WaitForPoolFill();
         LocalDbApi.StopAndDelete(instance, mode);
         DirectoryFinder.DeleteInstance(instance);
         DeleteDirectory();
@@ -436,6 +504,7 @@ class Wrapper : IDisposable
     [Time]
     public void DeleteInstance(ShutdownMode mode, TimeSpan timeout)
     {
+        WaitForPoolFill();
         LocalDbApi.StopAndDelete(instance, mode, timeout);
         DirectoryFinder.DeleteInstance(instance);
         DeleteDirectory();


### PR DESCRIPTION
Two changes to the pooled database path, plus three measurements that argued against changing anything else.

## Fill the pooled databases in the background

`CreatePool` built all `PoolSize` databases before returning, so the first pooled test paid every file copy and attach up front, and any test starting concurrently queued behind `poolLock` for the whole build. `PoolSize` defaults to `ProcessorCount`, so that is 16-32 serial database creations before the first test runs.

Only the first database is now awaited. The rest fill in on a background task while tests run, so the wait overlaps with useful work. The lease semaphore starts empty and gains a permit as each database lands, which changes a lease wait from "every pooled database is leased" to "every database built so far is leased".

The fill stays serial deliberately: it now runs alongside live tests, and `PoolSize` concurrent file copies would just compete with them for the same disk.

A background failure cannot hang the pool. `FillPool` records the cause and releases one permit per unbuilt database, so every parked waiter wakes, fails the dequeue, puts its permit back for the next caller, and rethrows the cause. Leases arriving afterwards fail fast on the same check. Teardown waits for the fill, since `DeleteInstance` deletes the directory a background copy may still be writing into.

`PooledFillFailureTests` covers that failure path by faulting the fill while a second lease is parked on the semaphore. It is mutation checked: with the wake-up release commented out it fails at the 30s timeout, and passes in 8s with it restored.

## Disable page verification on the template

`page_verify` defaulted to `checksum`, so the engine computed a checksum over every 8KB page as it was written to disk, and re-verified it on read, to detect storage corrupting a page underneath it. These databases are built from a template and deleted with the run, so that signal is never read.

Set on the template, which persists it through detach/copy/attach into pooled, per-test and shared databases alike. Unlike `auto_close`, which the attach resets to the model default, `page_verify` survives - verified against all three database kinds.

`PageVerifyBenchmarks` measures it: a checkpoint-heavy insert of ~7500 data pages is ~5% faster on average, and `none` won all five trials, though between-run variance on the test machine is comparable to the effect. Bytes written are identical either way, so the saving is CPU, not I/O. Worth taking mainly because the thing given up is worthless here, not because the win is large.

## Measured and deliberately not applied

Three further settings were investigated. None resulted in a change, and the benchmarks are kept as the record so they are not re-litigated from scratch.

**`read_committed_snapshot off` for pooled** - the biggest win of the lot, and refused. A pooled database is leased exclusively, so its row versioning buys nothing: turning it off is worth ~11% wall clock, ~29% less write I/O and ~38% less read I/O, consistently across three runs. But RCSI is what lets a second connection to a leased database read while the lease holds an uncommitted write, and that is public API - `OpenNewConnection`, `NewConnectionOwnedDbContext` and `IDbContextFactory.CreateDbContext` all open one. Probed both ways against a real pooled lease mid-transaction: with RCSI on the read returns the last committed state, with it off it blocks until the command timeout. Not worth trading a documented API for 11%, especially as it would surface as a mysterious timeout.

**`accelerated_database_recovery`** - unusable. LocalDB is Express edition (`EngineEdition` 4) and enabling it fails with error 12128, regardless of syntax or connection.

**Substitutes for ADR** - none worth having, and none needed. `RollbackCostBenchmarks` sizes the gap ADR would close: a ~85us floor plus ~0.94us per modified row, so a test touching 10-100 rows spends under 0.2ms on rollback. Database snapshots do work on LocalDB and are the one available mechanism with ADR's shape, but `ResetStrategyBenchmarks` shows a revert is 370x slower than the rollback at 100 rows and 11x slower at 10000 - its cost is almost entirely fixed, so the gap narrows with write size but never closes at any volume a test reaches.

## Verification

Full suite green, 0 failures:

| Project | Tests |
| --- | --- |
| LocalDb.Tests | 126 passed, 2 skipped |
| EfLocalDb.Tests | 112 |
| EfLocalDb.Xunit.V3.Tests | 32 |
| EfLocalDb.NUnit.Tests | 32 |
| EfLocalDb.TUnit.Tests | 32 |
| EfLocalDb.MSTest.Tests | 31 |
| EfClassicLocalDb.Tests | 20 |

Solution builds clean across net8.0/net9.0/net10.0/net48 with `TreatWarningsAsErrors`. Pooled tests additionally run green at `LocalDBPoolSize` of 1, 2 and 8 - size 1 exercising the case where the fill loop never runs, size 2 putting four concurrent tests against two databases while the fill is still in flight.
